### PR TITLE
adding the notification function

### DIFF
--- a/app/Api/Telegram_Api/Bot.py
+++ b/app/Api/Telegram_Api/Bot.py
@@ -200,3 +200,192 @@ async def process_verification(message: Message, state: FSMContext):
             reply_markup=ReplyKeyboardRemove()
         )
         await state.set_state(Form.waiting_for_verification)
+
+async def notification_about_deadline():
+    while True:
+        resp = requests.get(f"{EXTERNAL_API_URL}milestones", headers=headers)
+        milestones = resp.json()
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        for m in milestones:
+            deadline = (
+                datetime.datetime.fromisoformat(m["deadline"].rstrip("Z"))
+                .replace(tzinfo=datetime.timezone.utc)
+            )
+            delta = deadline - now
+
+            if m["status"] != "in process" or m["notified"] == "all_notified":
+                continue
+
+            schedule = [
+                (datetime.timedelta(days=7),   "in_7_days",    "in_3_days",    "7 days"),
+                (datetime.timedelta(days=3),   "in_3_days",    "in_1_day",     "3 days"),
+                (datetime.timedelta(days=1),   "in_1_day",     "in_12_hours",  "1 day"),
+                (datetime.timedelta(hours=12), "in_12_hours",  "in_1_hour",    "12 hours"),
+                (datetime.timedelta(hours=1),  "in_1_hour",    "deadline",     "1 hour"),
+            ]
+
+            for threshold, need_state, next_state, label in schedule:
+                if delta > datetime.timedelta(0) and delta <= threshold and m["notified"] == need_state:
+                    theses = requests.get(
+                        f"{EXTERNAL_API_URL}theses", headers=headers
+                    ).json()
+                    for thesis in theses:
+                        try:
+                            student = requests.get(
+                                f"{EXTERNAL_API_URL}students?id=eq.{thesis['student_id']}",
+                                headers=headers
+                            ).json()[0]
+                            user = requests.get(
+                                f"{EXTERNAL_API_URL}users?id=eq.{student['user_id']}",
+                                headers=headers
+                            ).json()[0]
+                            await bot.send_message(
+                                chat_id=user["telegram_id"],
+                                parse_mode="HTML",
+                                text=(
+                                    f"❗️<b>Notification about deadline</b>❗️\n\n"
+                                    f"<b>Thesis title:</b> {thesis['title']}\n\n"
+                                    f"<b>Step:</b> {m['title']}\n\n"
+                                    f"<b>Description:</b> {m['description']}\n\n"
+                                    f"<b>Time left:</b> {label}"
+                                )
+                            )
+                        except Exception as e:
+                            print(f"❌ error with thesis {thesis['id']}: {e}")
+
+                    requests.patch(
+                        f"{EXTERNAL_API_URL}milestones?id=eq.{m['id']}",
+                        json={"notified": next_state},
+                        headers=headers
+                    )
+                    break
+            if delta <= datetime.timedelta(0) and m["notified"] == "deadline":
+                theses = requests.get(
+                    f"{EXTERNAL_API_URL}theses", headers=headers
+                ).json()
+                for thesis in theses:
+                    try:
+                        student = requests.get(
+                            f"{EXTERNAL_API_URL}students?id=eq.{thesis['student_id']}",
+                            headers=headers
+                        ).json()[0]
+                        user = requests.get(
+                            f"{EXTERNAL_API_URL}users?id=eq.{student['user_id']}",
+                            headers=headers
+                        ).json()[0]
+                        await bot.send_message(
+                            chat_id=user["telegram_id"],
+                            parse_mode="HTML",
+                            text=(
+                                f"❗️<b>Notification about deadline</b>❗️\n\n"
+                                f"<b>Thesis title:</b> {thesis['title']}\n\n"
+                                f"<b>Step:</b> {m['title']}\n\n"
+                                f"<b>Description:</b> {m['description']}\n\n"
+                                f"<b>Time left:</b> Time’s up!"
+                            )
+                        )
+                    except Exception as e:
+                        print(f"❌ error with thesis {thesis['id']}: {e}")
+                requests.patch(
+                    f"{EXTERNAL_API_URL}milestones?id=eq.{m['id']}",
+                    json={"notified": "all_notified"},
+                    headers=headers
+                )
+
+        respp = requests.get(f"{EXTERNAL_API_URL}meetings", headers=headers)
+        meetings = respp.json()
+        for m in meetings:
+            deadline = (
+                datetime.datetime.fromisoformat(m["date"].rstrip("Z"))
+                .replace(tzinfo=datetime.timezone.utc)
+            )
+            delta = deadline - now
+
+            if m["status"] != "in process" or m["notified"] == "all_notified":
+                continue
+
+            schedule = [
+                (datetime.timedelta(days=3),   "in_3_days",    "in_12_hours",     "3 days"),
+                (datetime.timedelta(hours=12), "in_12_hours",  "in_1_hour",    "12 hours"),
+                (datetime.timedelta(hours=1),  "in_1_hour",    "deadline",     "1 hour"),
+            ]
+
+            for threshold, need_state, next_state, label in schedule:
+                if delta > datetime.timedelta(0) and delta <= threshold and m["notified"] == need_state:
+                    group_id = m["peer_group_id"]
+                    students_from_group = requests.get(f"{EXTERNAL_API_URL}students?peer_group_id=eq.{group_id}", headers=headers)
+                    users_ids_per_group = [student["user_id"] for student in students_from_group.json()]
+                    supervisors_from_group_user_id = requests.get(
+                        f"{EXTERNAL_API_URL}supervisors?id=eq.{m['supervisor_id']}",
+                        headers=headers
+                    ).json()[0]["user_id"]
+                    name_supervisor = requests.get(
+                        f"{EXTERNAL_API_URL}users?id=eq.{supervisors_from_group_user_id}",
+                        headers=headers
+                    ).json()[0]["first_name"]
+                    surname_supervisor = requests.get(
+                        f"{EXTERNAL_API_URL}users?id=eq.{supervisors_from_group_user_id}",
+                        headers=headers
+                    ).json()[0]["last_name"] or " "
+                    for user in users_ids_per_group:
+                        try:
+                            await bot.send_message(
+                                chat_id= requests.get(f"{EXTERNAL_API_URL}users?id=eq.{user}", headers=headers).json()[0]["telegram_id"],
+                                parse_mode="HTML",
+                                text=(
+                                    f"❗️<b>Notification about meeting</b>❗️\n\n"
+                                    f"<b>Supervisor:</b> {name_supervisor} {surname_supervisor}\n\n"
+                                    f"<b>Goal:</b> {m['title']}\n\n"
+                                    f"<b>Description:</b> {m['description']}\n\n"
+                                    f"<b>Time left:</b> {label}"
+                                )
+                            )
+                        except Exception as e:
+                            print(f"❌ error with student {e}")
+
+                    requests.patch(
+                        f"{EXTERNAL_API_URL}meetings?id=eq.{m['id']}",
+                        json={"notified": next_state},
+                        headers=headers
+                    )
+                    break
+            if delta <= datetime.timedelta(0) and m["notified"] == "deadline":
+                group_id = m["peer_group_id"]
+                students_from_group = requests.get(f"{EXTERNAL_API_URL}students?peer_group_id=eq.{group_id}",
+                                                   headers=headers)
+                users_ids_per_group = [student["user_id"] for student in students_from_group.json()]
+                supervisors_from_group_user_id = requests.get(
+                    f"{EXTERNAL_API_URL}supervisors?id=eq.{m['supervisor_id']}",
+                    headers=headers
+                ).json()[0]["user_id"]
+                name_supervisor = requests.get(
+                    f"{EXTERNAL_API_URL}users?id=eq.{supervisors_from_group_user_id}",
+                    headers=headers
+                ).json()[0]["first_name"]
+                surname_supervisor = requests.get(
+                    f"{EXTERNAL_API_URL}users?id=eq.{supervisors_from_group_user_id}",
+                    headers=headers
+                ).json()[0]["last_name"] or " "
+                for user in users_ids_per_group:
+                    try:
+                        await bot.send_message(
+                            chat_id= requests.get(f"{EXTERNAL_API_URL}users?id=eq.{user}", headers=headers).json()[0]["telegram_id"],
+                            parse_mode="HTML",
+                            text=(
+                                f"❗️<b>Notification about meeting</b>❗️\n\n"
+                                f"<b>Supervisor:</b> {name_supervisor} {surname_supervisor}\n\n"
+                                f"<b>Goal:</b> {m['title']}\n\n"
+                                f"<b>Description:</b> {m['description']}\n\n"
+                                f"<b>Time left:</b> The meeting is start"
+                            )
+                        )
+                    except Exception as e:
+                        print(f"❌ error with student {e}")
+                requests.patch(
+                    f"{EXTERNAL_API_URL}milestones?id=eq.{m['id']}",
+                    json={"notified": "all_notified"},
+                    headers=headers
+                )
+
+        await asyncio.sleep(10)

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,9 @@
-from app.Api.Telegram_Api.Bot import dp, bot #notification_about_deadline
+from app.Api.Telegram_Api.Bot import dp, bot, notification_about_deadline
 import asyncio
 
 
 async def main():
-    # asyncio.create_task(notification_about_deadline())
+    asyncio.create_task(notification_about_deadline())
     await dp.start_polling(bot)
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
This MR enhances the notification workflow by introducing an initial “created” state that triggers an immediate notification when a new milestone or meeting is added. Previously, notifications only began at a fixed interval (e.g. 7 days before a milestone), so newly created items remained silent until they hit that threshold. With this change, users receive an instant acknowledgement and clarity on how much time remains.

# Changes

- [x] Default notified flag
- [x] Set the default notified value to "created" for newly inserted milestones and meetings.
- [x] Updated schedule logic
- [x] Prepended a (threshold, need_state, next_state, label) tuple for "created" in both milestones (7 days) and meetings (3 days) schedules.

Ensures that on creation, if the time-to-event is within the first interval, the bot sends the corresponding “Time left: X” message immediately and updates notified to the next state.

# Database patching

After sending the “created” notification, the code patches the record to advance notified to "in_7_days" or "in_3_days", respectively.

Backward compatibility

All existing milestones and meetings with other notified states continue through the usual 7d→3d→1d→…→deadline→all_notified cycle without interruption.

# Why

Immediate feedback: Users now know right away that their milestone or meeting has been registered in the system.

Consistent UI/UX: Provides a uniform notification pattern from creation through event completion.

Reduced confusion: Avoids cases where users expect confirmation but see no notification until days later.

# Testing

Create a new milestone with a deadline more than 7 days away → expect immediate “7 days remaining” notification and notified updated to "in_7_days".

Create a new meeting scheduled 2 days ahead → expect immediate “3 days remaining” notification and notified updated to "in_3_days".

Verify that existing records with in‑flight notifications follow the normal progression and that records with notified == "all_notified" are skipped.

Closes #4